### PR TITLE
Better support for Wilderness Factions

### DIFF
--- a/src/me/crafter/mc/lockettepro/Dependency.java
+++ b/src/me/crafter/mc/lockettepro/Dependency.java
@@ -78,7 +78,7 @@ public class Dependency {
 		if (factions != null){
 			try {
 				Faction faction = BoardColl.get().getFactionAt(PS.valueOf(block));
-				if (faction != null && !faction.getName().contains("Wilderness")){
+				if (faction != null && !faction.isNone()){
 					MPlayer mplayer = MPlayer.get(player);
 					if (mplayer != null){
 						Faction playerfaction = mplayer.getFaction();


### PR DESCRIPTION
Since you can actually change the Wilderness Faction name, this is more appropriate, as we are getting the ID of the Factions, which is unique and not editable.

Remember that old Factions versions have had some huge API changes, so if you're interested in compatibility with 2.4, 1.8 and 1.6 Factions, you have to define all those versions with different methods.