### PR TITLE
Update Dependency.java

### DIFF
--- a/src/me/crafter/mc/lockettepro/Dependency.java
+++ b/src/me/crafter/mc/lockettepro/Dependency.java
@@ -203,7 +203,7 @@ public class Dependency {
 			if (clanplayer != null){
 				Clan clan = clanplayer.getClan();
 				if (clan != null){
-					if (line.equals("[" + clan.getName() + "]")) return true;
+					if (line.equals("[" + clan.getTag() + "]")) return true;
 				}
 			}
 		} catch (Exception e){}


### PR DESCRIPTION
Change SimpleClans check to look for the clan's Tag instead of clan name as the default SimpleClans configuration allows for clan names that far exceed a sign's char limit while a tag's default char limit fits a sign.

Clan Tags are unique and do not allow spaces.