### PR TITLE
Ignore case-sensitivity on Clan Tags

### DIFF
--- a/src/me/crafter/mc/lockettepro/Dependency.java
+++ b/src/me/crafter/mc/lockettepro/Dependency.java
@@ -203,7 +203,7 @@ public class Dependency {
 			if (clanplayer != null){
 				Clan clan = clanplayer.getClan();
 				if (clan != null){
-					if (line.equals("[" + clan.getTag() + "]")) return true;
+					if (line.equalsIgnoreCase("[" + clan.getTag() + "]")) return true;
 				}
 			}
 		} catch (Exception e){}


### PR DESCRIPTION
Clan Tags are not case-sensitive (i.e. 1 user cannot have clan tag "Test" and another user have a clan with tag "TeSt")
This update just makes it easier for users to give their clan members access as we found that .getTag() returns the tag in all lowercase while users were used to typing their tag with whatever casing they usually have on their tag.